### PR TITLE
Exclude logback.xml from building jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,16 @@
                     <target>8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <excludes>
+                        <exclude>logback.xml</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Solve for #27 
The template `logback.xml` file should not ship with final jar, otherwise it will be imported on user side and cause error due to properties are not configured.