### PR TITLE
Fix java 8 DateTimeFormatter init after joda-time failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,6 @@
             <version>1.7.15</version>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.9.9</version>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/src/main/java/com/aliyun/openservices/log/logback/LoghubAppender.java
+++ b/src/main/java/com/aliyun/openservices/log/logback/LoghubAppender.java
@@ -75,7 +75,7 @@ public class LoghubAppender<E> extends UnsynchronizedAppenderBase<E> {
     private void doStart() {
         try {
             formatter = DateTimeFormat.forPattern(timeFormat).withZone(DateTimeZone.forID(timeZone));
-        }catch (Throwable e){
+        }catch (NoClassDefFoundError e){
             formatter1 = java.time.format.DateTimeFormatter.ofPattern(timeFormat).withZone(ZoneId.of(timeZone));
         }
         producer = createProducer();

--- a/src/main/java/com/aliyun/openservices/log/logback/LoghubAppender.java
+++ b/src/main/java/com/aliyun/openservices/log/logback/LoghubAppender.java
@@ -75,7 +75,7 @@ public class LoghubAppender<E> extends UnsynchronizedAppenderBase<E> {
     private void doStart() {
         try {
             formatter = DateTimeFormat.forPattern(timeFormat).withZone(DateTimeZone.forID(timeZone));
-        }catch (Exception e){
+        }catch (Throwable e){
             formatter1 = java.time.format.DateTimeFormatter.ofPattern(timeFormat).withZone(ZoneId.of(timeZone));
         }
         producer = createProducer();

--- a/src/main/java/com/aliyun/openservices/log/logback/LoghubAppender.java
+++ b/src/main/java/com/aliyun/openservices/log/logback/LoghubAppender.java
@@ -13,13 +13,10 @@ import com.aliyun.openservices.aliyun.log.producer.ProducerConfig;
 import com.aliyun.openservices.aliyun.log.producer.ProjectConfig;
 import com.aliyun.openservices.aliyun.log.producer.errors.ProducerException;
 import com.aliyun.openservices.log.common.LogItem;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 /**
@@ -58,9 +55,7 @@ public class LoghubAppender<E> extends UnsynchronizedAppenderBase<E> {
 
     protected String timeZone = "UTC";
     protected String timeFormat = "yyyy-MM-dd'T'HH:mmZ";
-    protected DateTimeFormatter formatter;
-
-    protected java.time.format.DateTimeFormatter formatter1;
+    protected DateTimeFormatter formatter = DateTimeFormatter.ofPattern(timeFormat).withZone(ZoneId.of(timeZone));
     private String mdcFields;
 
     @Override
@@ -73,11 +68,6 @@ public class LoghubAppender<E> extends UnsynchronizedAppenderBase<E> {
     }
 
     private void doStart() {
-        try {
-            formatter = DateTimeFormat.forPattern(timeFormat).withZone(DateTimeZone.forID(timeZone));
-        }catch (NoClassDefFoundError e){
-            formatter1 = java.time.format.DateTimeFormatter.ofPattern(timeFormat).withZone(ZoneId.of(timeZone));
-        }
         producer = createProducer();
         super.start();
     }
@@ -132,13 +122,8 @@ public class LoghubAppender<E> extends UnsynchronizedAppenderBase<E> {
         logItems.add(item);
         item.SetTime((int) (event.getTimeStamp() / 1000));
 
-        if(formatter!=null){
-            DateTime dateTime = new DateTime(event.getTimeStamp());
-            item.PushBack("time", dateTime.toString(formatter));
-        }else {
-            Instant instant = Instant.ofEpochMilli(event.getTimeStamp());
-            item.PushBack("time", formatter1.format(instant));
-        }
+        Instant instant = Instant.ofEpochMilli(event.getTimeStamp());
+        item.PushBack("time", formatter.format(instant));
 
         item.PushBack("level", event.getLevel().toString());
         item.PushBack("thread", event.getThreadName());


### PR DESCRIPTION
Error `NoClassDefFoundError` is thrown if joda-time is not included in classpath. `NoClassDefFoundError` is an `Error` only implements `Throwable` not `Exception` so that the catch block will success.